### PR TITLE
Add docs badge to README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -4,6 +4,7 @@ h1. Welcome to Prometheus 2.0
 !https://secure.travis-ci.org/biow0lf/prometheus2.0.png(Build Status)!:http://travis-ci.org/biow0lf/prometheus2.0
 !https://codeclimate.com/github/biow0lf/prometheus2.0.png!:https://codeclimate.com/github/biow0lf/prometheus2.0
 !https://coveralls.io/repos/biow0lf/prometheus2.0/badge.png?branch=master(Coverage Status)!:https://coveralls.io/r/biow0lf/prometheus2.0?branch=master
+!http://inch-ci.org/github/biow0lf/prometheus2.0.svg?branch=master!:http://inch-ci.org/github/biow0lf/prometheus2.0
 !https://badge.waffle.io/biow0lf/prometheus2.0.png?label=ready(Stories in Ready)!:http://waffle.io/biow0lf/prometheus2.0
 
 h2. Setup and run


### PR DESCRIPTION
Hi there,

you tried to take a look at your project on http://inch-ci.org but that did not work because of a routing error. It does work after a small [patch](https://github.com/inch-ci/inch_ci-web/commit/5127fc6112575ae82f99bd13f7d1b78a79a5c73d) to the service.

This badge is the result: http://inch-ci.org/github/biow0lf/prometheus2.0
